### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # VAR-Toolbox
 Ambrogio Cesa-Bianchi's VAR Toolbox
 
-The VAR Toolbox is a collection of Matlab routines to perform VAR analysis. The latest version is available in the v3dot0 folder.
+The VAR Toolbox is a collection of Matlab routines to perform vector autoregressive (VAR) analysis. The latest version is available in the v3dot0 folder.
 
 Estimation is performed with OLS. The VAR Toolbox allows for identification of structural shocks with zero short-run restrictions; zero long-run restrictions; sign restrictions; external instruments (proxy SVAR); and a combination of external instruments and sign restrictions. Impulse Response Functions (IR), Forecast Error Variance Decomposition (VD), and Historical Decompositions (HD) are computed according to the chosen identification. Error bands are obtained with bootstrapping. 
 


### PR DESCRIPTION
Update readme spelling out the VAR acronym as "vector autoregressive" (double-check with @ambropo) in the first instance it occurs.